### PR TITLE
Fix for frameworks

### DIFF
--- a/OPUIKit/Source/OPNavigationController.m
+++ b/OPUIKit/Source/OPNavigationController.m
@@ -28,7 +28,7 @@
 
 +(id) controllerWithRootViewController:(UIViewController*)rootViewController {
 
-	OPNavigationController *controller = [[[NSBundle mainBundle] loadNibNamed:NSStringFromClass([self class]) owner:self options:nil] lastObject];
+	OPNavigationController *controller = [[[NSBundle bundleForClass:self] loadNibNamed:NSStringFromClass(self) owner:self options:nil] lastObject];
 
   if (rootViewController) {
     controller.viewControllers = @[rootViewController];


### PR DESCRIPTION
Since frameworks have their own bundle, we need to make sure the correct resource is loaded for this bundle. The motivation behind this came from configuring cocoapods to use frameworks, which is necessary for Swift pods. love gina & stephen
